### PR TITLE
apns-conf.xml: Add SIMPLE Mobile APN

### DIFF
--- a/working/system/etc/apns-conf.xml
+++ b/working/system/etc/apns-conf.xml
@@ -201,6 +201,14 @@
       type="mms"
   />
 
+  <apn carrier="SIMPLE Mobile"
+       mcc="310"
+       mnc="260"
+       apn="simple"
+       mmsc="http://smpl.mms.msg.eng.t-mobile.com/mms/wapenc"
+       type="default,supl,mms,admin"
+  />
+
   <apn carrier="Ben Internet Abonnee"
       mcc="204"
       mnc="16"


### PR DESCRIPTION
I noticed that the APN I needed wasn't present, so I added it. It is present in apns-full-conf.xml, albeit under a different name (Tracfone I believe), but not in the config that is actually used (I think).

I got the APN directly from here: http://www.simplemobile.com/wps/portal/home/support/phone-programming

Warm regards,
- Connor Baker
