### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Build Status](https://travis-ci.org/Android-L-Porting-Team/Android-L-Mako.svg?branch=master)](https://travis-ci.org/Android-L-Porting-Team/Android-L-Mako)
-#Android L Mako
+# Android L Mako
 Files for the Android L port to the Nexus 4. 
 LEGACY and not used anymore
 please use https://github.com/Android-L-Porting-Team/Mako-L-Rebase
-##Build Requirements
+## Build Requirements
 The makefiles assume a linux environment where `abootimg` is avaliable. This is avaliable as a package for most distributions:
 * Debian/Ubuntu: `# apt-get install abootimg`
 * Arch: `$ pacaur -S abootimg-git`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
